### PR TITLE
Renamed the function calls to dump_bits to dump_patch

### DIFF
--- a/scripts/sdb_dump_patch.py
+++ b/scripts/sdb_dump_patch.py
@@ -110,7 +110,7 @@ def _main(sdb_path, patch_name):
                 continue
 
             bits = item_get_child(patch, SDB_TAGS.TAG_PATCH_BITS)
-            dump_bits(bits, arch=ARCH_32)
+            dump_patch(bits, arch=ARCH_32)
 
     try:
         patch = item_get_child(s.database_root, SDB_TAGS.TAG_PATCH)
@@ -122,7 +122,7 @@ def _main(sdb_path, patch_name):
 
         if name == patch_name:
             bits = item_get_child(patch, SDB_TAGS.TAG_PATCH_BITS)
-            dump_bits(bits, arch=ARCH_32)
+            dump_patch(bits, arch=ARCH_32)
 
 
 def main():


### PR DESCRIPTION
The function dump_bits is missing. Maybe dump_bits was renamed to dump_patch at some point but the references were not updated.